### PR TITLE
Update to upstream 4.1.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
         "fr": "Une application web de comptes partagés à plusieurs"
     },
     "url": "http://ihatemoney.org/",
-    "version": "4.1.3~ynh2",
+    "version": "4.1.4~ynh2",
     "license": "free",
     "maintainer": {
         "name": "Jocelyn Delalande",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -41,12 +41,10 @@ init_virtualenv () {
 }
 
 pip_install () {
-    # Werkzeug stuff is workaround https://github.com/spiral-project/ihatemoney/issues/540
     sudo /opt/yunohost/ihatemoney/venv/bin/pip install --upgrade \
      'gunicorn>=19.3.0' \
      'PyMySQL>=0.9,<0.10' \
      'ihatemoney>=4,<5' \
-     'Werkzeug==0.16' \
 
 }
 


### PR DESCRIPTION
The werkzeug workaround is no longer needed.