### PR TITLE
Do not integrate supervisor in yunohost's service list

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -50,7 +50,6 @@ configure_supervisor
 # In case it was already installed before,
 # so that it picks /etc/supervisor/conf.d/ihatemoney.conf:
 supervisorctl update
-yunohost service add supervisor
 
 # Configure ihatemoney
 ynh_replace_string "MY_SECRET_KEY" "$secret_key"   ../conf/ihatemoney.cfg


### PR DESCRIPTION
Because it triggers warnings/error in the linter (if you add the service in the install, you should remove it in the remove, and also (re)add it in upgrade en restore). 

The spirit of "yunohost service add" is more about the app service itself rather than a technical tool like supervisor ? (Though not sure what's supervisor anyway) So proposing to just remove that line